### PR TITLE
Fix keyword loading to use any whitespace as separator

### DIFF
--- a/app/src/processing/app/syntax/PdeKeywords.java
+++ b/app/src/processing/app/syntax/PdeKeywords.java
@@ -116,7 +116,7 @@ public class PdeKeywords {
           continue;
         }
 
-        String pieces[] = PApplet.split(line, '\t');
+        String pieces[] = line.split("\\s+", 4);
 
         String keyword = pieces[0].trim();
         if (keyword.startsWith("\\#")) {


### PR DESCRIPTION
Instead of forcing keywords.txt to use tabs, let library developers use spaces too.